### PR TITLE
Add Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: vendor/bin/heroku-php-apache2 public/ 


### PR DESCRIPTION
Heroku uses to procfile to serve the laravel application, so that we can access the app using / instead of /public